### PR TITLE
Fix duplicate pages with GET parameters using robots.txt Clean-param directive

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,15 +5,3 @@ Your forked repository: konard/slava
 Original repository (upstream): ideav/slava
 
 Proceed.
-
----
-
-Issue to solve: https://github.com/ideav/slava/issues/11
-Your prepared branch: issue-11-cf264a48ed49
-Your prepared working directory: /tmp/gh-issue-solver-1762697887119
-Your forked repository: konard/slava
-Original repository (upstream): ideav/slava
-
-Proceed.
-
-Run timestamp: 2025-11-09T14:18:17.264Z


### PR DESCRIPTION
## 📋 Issue Reference
Fixes #11

## 🎯 Problem
Some pages with GET parameters in the URL duplicate the contents of other pages without GET parameters. For example, `https://example.com/tovary?from=mainpage` duplicates `https://example.com/tovary`. This causes:
- Longer crawling times for important pages
- Duplicate content in search indexes
- Diluted search signals across identical pages

## ✅ Solution
Created a `robots.txt` file with Yandex-specific `Clean-param` directives to instruct search engines to ignore tracking and referral GET parameters when indexing pages.

## 📝 Implementation Details

### Added `robots.txt` file with:
- General rules allowing all crawlers
- Yandex-specific `Clean-param` directives for common tracking parameters:
  - `from` - referral tracking parameter (specifically mentioned in the issue)
  - `utm_source`, `utm_medium`, `utm_campaign`, `utm_term`, `utm_content` - UTM tracking parameters
  - `fbclid`, `gclid`, `yclid` - Social media and ad click tracking
  - `ref`, `source` - General referral parameters

### How it works:
When Yandex bot encounters URLs like:
- `https://example.com/gallery.html?from=mainpage`
- `https://example.com/gallery.html?utm_source=email`
- `https://example.com/contact.html?ref=homepage`

It will treat them as identical to their base URLs:
- `https://example.com/gallery.html`
- `https://example.com/contact.html`

This consolidates search signals to the main pages and prevents duplicate indexing.

## 🧪 Testing
- ✅ Created valid `robots.txt` file
- ✅ Syntax follows Yandex robots.txt specifications
- ✅ File placed in website root directory

## 📚 References
- Yandex Clean-param directive: https://yandex.com/support/webmaster/controlling-robot/robots-txt.html

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)